### PR TITLE
chore(package.json): Add trim dependency to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,14 +8,11 @@
   "description": "Strip the sourceMappingURL comment from a file",
   "author": "Aaike Van Roekeghem",
   "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "git@bitbucket.org:aaike/gulp-strip-sourcemapurl.git"
-  },
   "main": "gulp-strip-sourcemapurl.js",
   "dependencies": {
     "gulp": "~3.8",
-    "through2": "~0.6"
+    "through2": "~0.6",
+    "trim": "0.0.1"
   },
   "devDependencies": {
     


### PR DESCRIPTION
You have trim as dependency on your code, so we need to install it.

It's easier to leave as dependency instead of install globally.

I also removed the bitbucket repository because it was duplicated and I believe you don't have this repo at bitbucket anymore.
